### PR TITLE
Fix #24: Pagination is broken, showing identical tasks on multiple pages.

### DIFF
--- a/le_chad/le_chad/app.py
+++ b/le_chad/le_chad/app.py
@@ -129,11 +129,11 @@ def create_task(task: TaskCreate):
 
 
 @app.get("/tasks")
-def list_tasks(page: int = 1, limit: int = 9999):
+def list_tasks(page: int = 1, limit: int = 10):
     conn = get_connection()
     c = conn.cursor()
     offset = (page - 1) * limit
-    c.execute("SELECT * FROM tasks LIMIT ? OFFSET ?", (limit, offset))
+    c.execute("SELECT * FROM tasks ORDER BY id ASC LIMIT ? OFFSET ?", (limit, offset))
     rows = c.fetchall()
 
     tasks = []


### PR DESCRIPTION
Closes #24

## Summary

The pagination issue has been fixed in the `list_tasks` function in `le_chad/le_chad/app.py`. Here's a summary of the changes made:

### Changes:
1. **Default Limit**:
   - Changed the default `limit` from `9999` to `10` to ensure pagination is meaningful and practical.

2. **Sorting**:
   - Added `ORDER BY id ASC` to the SQL query to ensure consistent ordering of tasks across pages. This prevents identical tasks from appearing on multiple pages due to inconsistent ordering.

### Updated Code:
```python
@app.get("/tasks")
def list_tasks(page: int = 1, limit: int = 10):
    conn = get_connection()
    c = conn.cursor()
    offset = (page - 1) * limit
    c.execute("SELECT * FROM tasks ORDER BY id ASC LIMIT ? OFFSET ?", (limit, offset))
    rows = c.fetchall()

    tasks = []
    for r in rows:
        # N+1: fetch comment count per task
        c2 = conn.cursor()
        c2.execute("SELECT COUNT(*) FROM comments WHERE task_id = ?", (r[0],))
        count = c2.fetchone()[0]
        tasks.append({
            "id": r[0],
            "title": r[1],
            "description": r[2],
            "status": r[3],
            "assignee": r[4],
            "priority": r[5],
            "project_id": r[6],
            "created_at": r[7],
            "comment_count": count,
        })

    conn.close()
    return tasks
```

### Why This Fixes the Issue:
- **Consistent Ordering**: By sorting tasks by `id`, the pagination results are now consistent and predictable.
- **Practical Pagination**: The reduced default limit ensures that pagination is functional and user-friendly.

The issue described in GitHub Issue #24 should now be resolved.

---
*Automated by ChadBot*